### PR TITLE
Đổi lại neural network trong glossary 

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -46,7 +46,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | metric                            | phép đo                                                        |                              |
 | multiple-number evaluation metric | phép đo đa trị                                                 |                              |
 | negative sample/example           | mẫu âm                                                         |                              |
-| neural network                    | neural network                                                 | [#87](http://bit.ly/2BvfPYA) |
+| neural network                    | mạng neural                                                    | [#87](http://bit.ly/2BvfPYA) |
 | overfit                            | overfit                                                         | [#87](http://bit.ly/2BvfPYA) |
 | optimizing metric                 | phép đo để tối ưu                                              | [#87](http://bit.ly/2BvfPYA) |
 | positive sample/example           | mẫu dương                                                      |                              |


### PR DESCRIPTION
Mình revert từ này vì các chương từ đầu tới giờ vẫn dịch là 'mạng neural'.

Nếu sửa lại thành 'neural network' hay 'mạng neuron' thì phải sửa toàn bộ từ đầu. Bạn có thể tạo một PR mới cho việc này để tránh nhầm lẫn.