### PR TITLE
Thêm glossary black box/ eyeball dev set 

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -20,7 +20,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | benchmark                         | đánh giá xếp hạng                                              | [#87](http://bit.ly/2BvfPYA)                               |
 | bias (bias as variance)           | độ chệch                                                       | [#125](http://bit.ly/32HJI3S)                              |
 | big data                          | big data                                                       |                                                            |
-| Blackbox dev set                  |  tập phát triển đóng                                                              |                                                            |
+| Blackbox dev set                  |  tập phát triển Blackbox                                                              |                                                            |
 | classifier                        | bộ phân loại                                                   |                                                            |
 | constrain                         | ràng buộc                                                      |                                                            |
 | cross validation                  | kiểm định chéo                                                 |                                                            |
@@ -32,7 +32,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | error rate                        | tỉ lệ lỗi                                                      |                                                            |
 | evaluation metric                 | phép đánh giá                                                  |                                                            |
 | example                           | mẫu                                                            |                                                            |
-| Eyeball dev set                   |    Tập phát triển mở                                                            |                                                            |
+| Eyeball dev set                   |    Tập phát triển Eyeball                                                            |                                                            |
 | F1 score                          | chỉ số F1                                                      |                                                            |
 | false negative                    | âm tính giả                                                    |                                                            |
 | false positive                    | dương tính giả                                                 |                                                            |

--- a/glossary.md
+++ b/glossary.md
@@ -20,7 +20,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | benchmark                         | đánh giá xếp hạng                                              | [#87](http://bit.ly/2BvfPYA)                               |
 | bias (bias as variance)           | độ chệch                                                       | [#125](http://bit.ly/32HJI3S)                              |
 | big data                          | big data                                                       |                                                            |
-| Blackbox dev set                  |                                                                |                                                            |
+| Blackbox dev set                  |  tập phát triển đóng                                                              |                                                            |
 | classifier                        | bộ phân loại                                                   |                                                            |
 | constrain                         | ràng buộc                                                      |                                                            |
 | cross validation                  | kiểm định chéo                                                 |                                                            |
@@ -32,7 +32,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | error rate                        | tỉ lệ lỗi                                                      |                                                            |
 | evaluation metric                 | phép đánh giá                                                  |                                                            |
 | example                           | mẫu                                                            |                                                            |
-| Eyeball dev set                   |                                                                |                                                            |
+| Eyeball dev set                   |    Tập phát triển mở                                                            |                                                            |
 | F1 score                          | chỉ số F1                                                      |                                                            |
 | false negative                    | âm tính giả                                                    |                                                            |
 | false positive                    | dương tính giả                                                 |                                                            |


### PR DESCRIPTION
Trong quá trình dịch chương 17 em có gặp 2 từ black box dev set và eyeball dev set. Em định dịch là tập phát triển mở / tập phát triển đóng (hoặc kín) nhưng dịch 2 thuật ngữ này còn ảnh hưởng đến cách dịch của câu ngay sau đấy:

 You should randomly select 10% of the dev set and place that into what we’ll call an ​**Eyeball dev set**​ to remind ourselves that we are looking at it with our eyes. (For a project on speech recognition, in which you would be listening to audio clips, perhaps you would call this set an Ear dev set instead).

Mong mọi người cho ý kiến ạ 