### PR TITLE
Thêm "domain adaptation" và "multitask learning" vào glossary.md

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -29,7 +29,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | development set                   | tập phát triển                                                 |                                                            |
 | dev set                           | tập phát triển                                                 |                                                            |
 | distribution                      | phân phối                                                      |                                                            |
-| domain adaptation                 | thích ứng miền giá trị                                         |                                                            |
+| domain adaptation                 | sự thích nghi lĩnh vực                                         |                                                            |
 | dropout                           |                                                                |                                                            |
 | early stopping                    | dừng sớm                                                       |                                                            |
 | error analysis                    | phân tích lỗi                                                  |                                                            |

--- a/glossary.md
+++ b/glossary.md
@@ -29,6 +29,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | development set                   | tập phát triển                                                 |                                                            |
 | dev set                           | tập phát triển                                                 |                                                            |
 | distribution                      | phân phối                                                      |                                                            |
+| domain adaptation                 | thích ứng miền giá trị                                         |                                                            |
 | dropout                           |                                                                |                                                            |
 | early stopping                    | dừng sớm                                                       |                                                            |
 | error analysis                    | phân tích lỗi                                                  |                                                            |
@@ -59,6 +60,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | mislabeled                        | bị gán nhãn nhầm                                               |                                                            |
 | model                             | mô hình                                                        |                                                            |
 | multiple-number evaluation metric | phép đo đa trị                                                 |                                                            |
+| multitask learning                | học đa nhiệm                                                   |                                                            |
 | negative sample/example           | mẫu âm                                                         |                                                            |
 | neural network                    | mạng neural                                                    | [#87](http://bit.ly/2BvfPYA) [#115](http://bit.ly/2MAkizG) |
 | optimizing metric                 | phép đo để tối ưu                                              | [#87](http://bit.ly/2BvfPYA)                               |

--- a/glossary.md
+++ b/glossary.md
@@ -29,7 +29,7 @@ Nếu một từ chưa có trong bảng thuật ngữ dưới đây, các bạn 
 | development set                   | tập phát triển                                                 |                                                            |
 | dev set                           | tập phát triển                                                 |                                                            |
 | distribution                      | phân phối                                                      |                                                            |
-| domain adaptation                 | sự thích nghi lĩnh vực                                         |                                                            |
+| domain adaptation                 | thích ứng miền                                                 |                                                            |
 | dropout                           |                                                                |                                                            |
 | early stopping                    | dừng sớm                                                       |                                                            |
 | error analysis                    | phân tích lỗi                                                  |                                                            |


### PR DESCRIPTION
Hai từ "domain adaptation" và "multitask learning" xuất hiện trong chương 36. Ở đoạn

> There is some academic research on training and testing on different distributions. Examples include **“domain adaptation,”** “transfer learning” and **“multitask learning.”** But there is still a huge gap between theory and practice. If you train on dataset A and test on some very different type of data B, luck could have a huge effect on how well your algorithm performs. (Here, “luck” includes the researcher’s hand-designed features for the particular task, as well as other factors that we just don’t understand yet.) This makes the academic study of training and testing on different distributions difficult to carry out in a systematic way

Mong mọi người góp ý về cách dịch hai thuật ngữ này.
